### PR TITLE
`BenchmarkHash` function, the parameter `h` is changed from `maphash` to `*maphash.Hash`

### DIFF
--- a/tests/runtime/memhash_test.go
+++ b/tests/runtime/memhash_test.go
@@ -1,36 +1,34 @@
 package main
 
 import (
-	"hash/maphash"
-	"strconv"
-	"testing"
+    "hash/maphash"
+    "strconv"
+    "testing"
 )
 
 var buf [8192]byte
 
 func BenchmarkMaphash(b *testing.B) {
-	var h maphash.Hash
-	benchmarkHash(b, "maphash", h)
+    var h maphash.Hash
+    benchmarkHash(b, "maphash", &h)
 }
 
-func benchmarkHash(b *testing.B, str string, h maphash.Hash) {
-	var sizes = []int{1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1024, 8192}
-	for _, n := range sizes {
-		b.Run(strconv.Itoa(n), func(b *testing.B) { benchmarkHashn(b, int64(n), h) })
-	}
+func benchmarkHash(b *testing.B, str string, h *maphash.Hash) {
+    var sizes = []int{1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1024, 8192}
+    for _, n := range sizes {
+        b.Run(strconv.Itoa(n), func(b *testing.B) { benchmarkHashn(b, int64(n), h) })
+    }
 }
 
 var total uint64
 
-func benchmarkHashn(b *testing.B, size int64, h maphash.Hash) {
-	b.SetBytes(size)
-
-	sum := make([]byte, 4)
-
-	for i := 0; i < b.N; i++ {
-		h.Reset()
-		h.Write(buf[:size])
-		sum = h.Sum(sum[:0])
-		total += uint64(sum[0])
-	}
+func benchmarkHashn(b *testing.B, size int64, h *maphash.Hash) {
+    b.SetBytes(size)
+    sum := make([]byte, 4)
+    for i := 0; i < b.N; i++ {
+        h.Reset()
+        h.Write(buf[:size])
+        h.Sum(sum[:0])
+        total += uint64(sum[0])
+    }
 }


### PR DESCRIPTION
In the `benchmarkHash` function, the parameter `h` is changed from `maphash.Hash` to `*maphash.Hash`. This is because `maphash.Hash` is a struct, not an interface, and should be passed as a pointer. 

It should also be noted in the `benchmarkHashn` function, the size of the sum slice was set to `4`, which may not be sufficient for all hash implementations. Instead, it should use `h.Size()` to determine the appropriate size based on the hash implementation.


```go
func BenchmarkMaphash(b *testing.B) {
    var h maphash.Hash
    benchmarkHash(b, "maphash", h)
}
```

The blame is below: 

https://github.com/redpanda-data/tinygo/blame/b8498403dd57cdf373280f663d67ffb5bb7eae44/tests/runtime/memhash_test.go#L11

In the `BenchmarkMaphash` function, when calling `benchmarkHash`, the `&` operator is added before `h` to pass the address of `h` instead of the value.

```go
func benchmarkHash(b *testing.B, str string, h maphash.Hash) {
    // ...
}
```

The blame is below:

https://github.com/redpanda-data/tinygo/blame/b8498403dd57cdf373280f663d67ffb5bb7eae44/tests/runtime/memhash_test.go#L15

Cheers,
Michael Mendy